### PR TITLE
fix bug due to qhull update

### DIFF
--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -214,28 +214,25 @@ get_uniquefacets(bz)
  [8, 7, 5, 6]
 ```
 """
-function get_uniquefacets(ch::Chull{<:Real})::Vector{Vector{<:Integer}}
+function get_uniquefacets(ch::Chull{<:Real})
     facets = ch.facets
-    unique_facets = []
-    removed=zeros(Int64,size(facets,1))
+    unique_facets = Vector{eltype(ch.vertices)}[]
+    removed=zeros(Bool,size(facets,1))
     for i=1:size(facets,1)
-        if removed[i] == 0
-            removed[i]=1
-            face=get_simplex(ch.simplices, i)
-            for j=i+1:size(facets,1)
-                if isapprox(facets[i,:],facets[j,:],rtol=1e-6)
-                    removed[j]=1
-                    append!(face,get_simplex(ch.simplices, j))
-                end
+        removed[i] && continue
+        removed[i]=true
+        face=get_simplex(ch.simplices, i)
+        for j=i+1:size(facets,1)
+            if isapprox(facets[i,:],facets[j,:],rtol=1e-6)
+                removed[j]=true
+                append!(face,get_simplex(ch.simplices, j))
             end
-            face = unique(reduce(hcat,face)[:])
-            # Order the corners of the face either clockwise or
-            # counterclockwise.
-            face = face[sortpts_perm(Array(ch.points[face,:]'))]
-            append!(unique_facets,[face])
         end
+        unique!(face)
+        # Order the corners of the face either clockwise or counterclockwise.
+        permute!(face, sortpts_perm(ch.points[face,:]'))
+        push!(unique_facets,face)
     end
-    # unique_facets = convert(Array{Array{Int,1}},unique_facets)
     unique_facets
 end
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -174,7 +174,7 @@ function edgelengths(basis::AbstractMatrix{<:Real}, radius::Real;
     end
 end
 
-get_simplex(v::Vector{Vector{<:Real}}, i) = v[i]
+get_simplex(v::Vector{<:Vector{<:Real}}, i) = v[i]
 get_simplex(v::Matrix{<:Real}, i) = v[i,:]
 
 

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -174,6 +174,10 @@ function edgelengths(basis::AbstractMatrix{<:Real}, radius::Real;
     end
 end
 
+get_simplex(v::Vector{Vector{<:Real}}, i) = v[i]
+get_simplex(v::Matrix{<:Real}, i) = v[i,:]
+
+
 @doc """
     get_uniquefacets(ch)
 
@@ -210,18 +214,18 @@ get_uniquefacets(bz)
  [8, 7, 5, 6]
 ```
 """
-function get_uniquefacets(ch::Chull{<:Real})::Vector{Vector{<:Int}}
+function get_uniquefacets(ch::Chull{<:Real})::Vector{Vector{<:Integer}}
     facets = ch.facets
     unique_facets = []
     removed=zeros(Int64,size(facets,1))
     for i=1:size(facets,1)
         if removed[i] == 0
             removed[i]=1
-            face=ch.simplices[i]
+            face=get_simplex(ch.simplices, i)
             for j=i+1:size(facets,1)
                 if isapprox(facets[i,:],facets[j,:],rtol=1e-6)
                     removed[j]=1
-                    append!(face,ch.simplices[j])
+                    append!(face,get_simplex(ch.simplices, j))
                 end
             end
             face = unique(reduce(hcat,face)[:])


### PR DESCRIPTION
In QHull v0.2.4, the data layout of simplices changes and breaks `SymmetryReduceBZ.Utilities.get_uniquefacets`. This pr fixes the bug and is compatible with current and previous versions of QHull.
See https://github.com/JuliaPolyhedra/QHull.jl/pull/41 for more details