### PR TITLE
[v0.2] Move Python dependencies into extensions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.9'
           - '1'
 #          - 'nightly'
         os:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.6'
+          version: '1.9'
       - name: Install dependencies
         run: PYTHON='' julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,11 @@
 name = "SymmetryReduceBZ"
 uuid = "49a35663-c880-4242-bebb-1ec8c0fa8046"
 authors = ["Jeremy Jorgensen <jerjorg@gmail.com>"]
-version = "0.1.9"
+version = "0.2.0"
+
+[weakdeps]
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 
 [deps]
 CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"
@@ -9,8 +13,6 @@ Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Polyhedra = "67491407-f73d-577b-9b50-8179a7c68029"
-PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
-PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 QHull = "a8468747-bd6f-53ef-9e5c-744dbc5c59e7"
 
 [compat]
@@ -18,14 +20,17 @@ Aqua = "0.8"
 CDDLib = "0.9"
 Combinatorics = "1"
 Distances = "0.10"
-LinearAlgebra = "1.6"
+LinearAlgebra = "1.9"
 Polyhedra = "0.6,0.7"
 PyCall = "1.9"
 PyPlot = "2.9"
 QHull = "0.2"
 SymPy = "1,2"
-Test = "1.6"
-julia = "1.6"
+Test = "1.9"
+julia = "1.9"
+
+[extensions]
+SymmetryReduceBZPyPlotExt = ["PyPlot", "PyCall"]
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -34,6 +39,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QHull = "a8468747-bd6f-53ef-9e5c-744dbc5c59e7"
 SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 
 [targets]
-test = ["Aqua", "Test", "SymPy", "CDDLib", "LinearAlgebra", "QHull"]
+test = ["Aqua", "Test", "SymPy", "CDDLib", "LinearAlgebra", "QHull", "PyPlot"]

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ for additional attributes of the IBZ.
 
 The function `plot_convexhulls` is useful for visualizing the Brillouin zone
 and irreducible Brillouin zone. The arguments are the same as those from
-`calc_ibz`.
+`calc_ibz`. It is available through a package extension with PyPlot.
 ```@example
+using PyPlot
 import SymmetryReduceBZ.Plotting: plot_convexhulls
 import SymmetryReduceBZ.Lattices: genlat_CUB
 a = 2.0
@@ -106,6 +107,7 @@ The functions `plot_2Dconvexhull` and `plot_3Dconvexhull` allow greater customiz
 the appearance of the convex hull.
 
 ```@example
+using PyPlot
 import SymmetryReduceBZ.Symmetry: calc_bz, calc_ibz
 import SymmetryReduceBZ.Plotting: plot_2Dconvexhull
 using PyPlot
@@ -125,9 +127,9 @@ axis("off")
 ![IBZ](https://github.com/jerjorg/SymmetryReduceBZ.jl/blob/master/plots/ibz-3.png)
 
 ```@example
+using PyPlot
 import SymmetryReduceBZ.Symmetry: calc_bz, calc_ibz
 import SymmetryReduceBZ.Plotting: plot_3Dconvexhull
-using PyPlot
 real_latvecs = [1 0 0; 0 1 0; 0 0 1]
 convention="ordinary"
 atom_types=[0]

--- a/docs/src/Usage.md
+++ b/docs/src/Usage.md
@@ -25,6 +25,7 @@ gives the convention for going from real to reciprocal space (whether or not to
 multiply by 2π). There is a simple function for visualizing the IBZ along with
 the Brillouin zone (BZ).
 ```@example
+using PyPlot
 import SymmetryReduceBZ.Plotting: plot_convexhulls
 import SymmetryReduceBZ.Lattices: genlat_CUB
 a = 2.0
@@ -51,6 +52,8 @@ jl = Julia(runtime="/usr/local/bin/julia")
 %%julia
 using Pkg
 Pkg.add("SymmetryReduceBZ")
+Pkg.add("PyPlot")
+using PyPlot
 import SymmetryReduceBZ.Plotting: plot_convexhulls
 import SymmetryReduceBZ.Lattices: genlat_CUB
 
@@ -75,6 +78,8 @@ jl = Julia(runtime="/usr/local/bin/julia")
 jl.eval("""
 using Pkg
 Pkg.add(\"SymmetryReduceBZ\")
+Pkg.add(\"PyPlot\")
+using PyPlot
 import SymmetryReduceBZ.Plotting: plot_convexhulls
 import SymmetryReduceBZ.Lattices: genlat_CUB
 a = 1.0

--- a/ext/SymmetryReduceBZPyPlotExt.jl
+++ b/ext/SymmetryReduceBZPyPlotExt.jl
@@ -1,0 +1,107 @@
+module SymmetryReduceBZPyPlotExt
+
+ENV["MPLBACKEND"]="qt5agg"
+
+import SymmetryReduceBZ.Symmetry: calc_bz, calc_ibz
+import SymmetryReduceBZ.Utilities: get_uniquefacets
+import SymmetryReduceBZ.Plotting: plot_convexhulls, plot_2Dconvexhull, plot_3Dconvexhull
+import QHull: Chull
+import PyCall: PyObject, pyimport
+import PyPlot: figaspect, figure, subplots
+
+function plot_2Dconvexhull(convexhull::Chull{<:Real},
+    ax::Union{PyObject,Nothing}=nothing;facecolor::String="blue",
+    alpha::Real=0.3,linewidth::Real=3,edgecolor::String="black")::PyObject
+
+    bzpts=Array(convexhull.points')
+    c=[sum(bzpts[i,:])/size(bzpts,2) for i=1:2]
+    angles=zeros(size(bzpts,2))
+    for i=1:size(bzpts,2)
+        (x,y)=bzpts[:,i] - c
+        angles[i] = atan(y,x)
+    end
+    perm = sortperm(angles)
+    bzpts = bzpts[:,perm]
+    (x,y)=[bzpts[i,:] for i=1:2]
+
+    if ax === nothing fig,ax = subplots() end
+    ax.fill(x,y, facecolor=facecolor,edgecolor=edgecolor,
+        linewidth=linewidth,alpha=alpha)
+    ax.set_aspect(1)
+    ax
+end
+
+function plot_3Dconvexhull(convexhull::Chull{<:Real}, ax::Union{PyObject,Nothing}=nothing;
+    facecolors::String="blue",alpha::Real=0.3,linewidths::Real=1,edgecolors::String="black")::PyObject
+
+    ϵ=0.1*(convexhull.volume)^1/3
+    plotrange=[[minimum(convexhull.points[:,i])-ϵ,
+        maximum(convexhull.points[:,i])+ϵ] for i=1:3]
+
+    art3d=pyimport("mpl_toolkits.mplot3d.art3d")
+
+    facesᵢ=get_uniquefacets(convexhull)
+    edgesᵢ=deepcopy(facesᵢ)
+    for i=1:length(edgesᵢ)
+        append!(edgesᵢ[i],edgesᵢ[i][1])
+    end
+
+    faces=[convexhull.points[i,:] for i in facesᵢ]
+    edges=[convexhull.points[i,:] for i in edgesᵢ]
+
+    # Reshape faces and edges
+    faces=[[faces[j][i,:] for i=1:size(faces[j],1)] for j=1:length(faces)]
+    edges=[[edges[j][i,:] for i=1:size(edges[j],1)] for j=1:length(edges)]
+
+    p=art3d.Poly3DCollection(faces, alpha=alpha, facecolors=facecolors)
+    l=art3d.Line3DCollection(edges, colors=edgecolors,linewidths=linewidths)
+
+    if ax === nothing
+        fig = figure()
+        ax = fig.add_subplot(111, projection="3d")
+    end
+
+    ax.add_collection3d(p)
+    ax.add_collection3d(l)
+    ax.auto_scale_xyz(plotrange[1],plotrange[2],plotrange[3])
+    ax.set_box_aspect((1, 1, 1))
+
+    return ax
+end
+
+function plot_convexhulls(real_latvecs::AbstractMatrix{<:Real},
+    atom_types::AbstractVector{<:Int},atom_pos::AbstractMatrix{<:Real},
+    coords::String,makeprim::Bool,
+    convention::String,ax::Union{PyObject,Nothing}=nothing;
+    rtol::Real=sqrt(eps(float(maximum(real_latvecs)))),atol::Real=1e-9)::PyObject
+
+    format = "convex hull"
+    bz = calc_bz(real_latvecs,atom_types,atom_pos,coords,format,makeprim,
+        convention,rtol=rtol,atol=atol)
+    ibz = calc_ibz(real_latvecs,atom_types,atom_pos,coords,format,makeprim,
+        convention,rtol=rtol,atol=atol)
+    dim = size(real_latvecs,1)
+
+    if ax === nothing
+        if dim == 2
+            fig,ax=subplots(figsize=figaspect(1)*1.5)
+        elseif dim == 3
+            fig = figure(figsize=figaspect(1)*1.5)
+            ax = fig.add_subplot(111, projection="3d")
+        else
+            throw(ArgumentError("The lattice vectors must be in a 2x2 or 3x3
+                matrix."))
+        end
+    end
+
+    if dim == 2
+        ax = plot_2Dconvexhull(bz,ax,facecolor="deepskyblue")
+        ax = plot_2Dconvexhull(ibz,ax,facecolor="coral")
+    else # dim == 3
+        ax = plot_3Dconvexhull(ibz,ax,facecolors="lightcoral")
+        ax = plot_3Dconvexhull(bz,ax,facecolors="deepskyblue")
+    end
+    ax
+end
+
+end #module

--- a/src/Plotting.jl
+++ b/src/Plotting.jl
@@ -1,19 +1,16 @@
 module Plotting
 
-ENV["MPLBACKEND"]="qt5agg"
-
-import ..Symmetry: calc_bz, calc_ibz
-import ..Utilities: get_uniquefacets
-import QHull: Chull
-import PyCall: PyObject, pyimport
-import PyPlot: figaspect, figure, subplots
-
 export plot_convexhulls
 
 @doc """
     plot_2Dconvexhull(convexhull, ax, color)
 
 Plot a 2D convex hull
+
+!!! note "PyPlot.jl package extension"
+    This function is available through a package extension of
+    [PyPlot.jl](https://github.com/JuliaPy/PyPlot.jl).
+    After installing Python, Matplotlib, and PyPlot.jl, do `using PyPlot` to load it.
 
 # Arguments
 - `convexhull::Chull{<:Real}`: a convex hull object.
@@ -28,6 +25,7 @@ Plot a 2D convex hull
 
 # Examples
 ```julia
+using PyPlot
 import SymmetryReduceBZ.Symmetry: calc_bz, calc_ibz
 import SymmetryReduceBZ.Plotting: plot_2Dconvexhull
 real_latvecs = [1 0; 0 1]
@@ -45,35 +43,17 @@ ax = plot_2Dconvexhull(ibz,ax;facecolor="coral",linewidth=3,edgecolor="magenta",
 PyObject <AxesSubplot: >
 ```
 """
-function plot_2Dconvexhull(convexhull::Chull{<:Real},
-    ax::Union{PyObject,Nothing}=nothing;facecolor::String="blue",
-    alpha::Real=0.3,linewidth::Real=3,edgecolor::String="black")::PyObject
-
-    patch=pyimport("matplotlib.patches")
-    collections=pyimport("matplotlib.collections")
-
-    bzpts=Array(convexhull.points')
-    c=[sum(bzpts[i,:])/size(bzpts,2) for i=1:2]
-    angles=zeros(size(bzpts,2))
-    for i=1:size(bzpts,2)
-        (x,y)=bzpts[:,i] - c
-        angles[i] = atan(y,x)
-    end
-    perm = sortperm(angles)
-    bzpts = bzpts[:,perm]
-    (x,y)=[bzpts[i,:] for i=1:2]
-
-    if ax == nothing fig,ax = subplots() end
-    ax.fill(x,y, facecolor=facecolor,edgecolor=edgecolor,
-        linewidth=linewidth,alpha=alpha)
-    ax.set_aspect(1)
-    ax
-end
+function plot_2Dconvexhull end
 
 @doc """
     plot_3Dconvexhull(convexhull,ax;color)
 
 Plot a 3D convex hull
+
+!!! note "PyPlot.jl package extension"
+    This function is available through a package extension of
+    [PyPlot.jl](https://github.com/JuliaPy/PyPlot.jl).
+    After installing Python, Matplotlib, and PyPlot.jl, do `using PyPlot` to load it.
 
 # Arguments
 - `convexhull::Chull{<:Real}`: a convex hull object.
@@ -88,9 +68,9 @@ Plot a 3D convex hull
 
 # Examples
 ```julia
+using PyPlot
 import SymmetryReduceBZ.Symmetry: calc_bz, calc_ibz
 import SymmetryReduceBZ.Plotting: plot_3Dconvexhull
-using PyPlot
 real_latvecs = [1 0 0; 0 1 0; 0 0 1]
 convention="ordinary"
 atom_types=[0]
@@ -108,48 +88,17 @@ ax = plot_3Dconvexhull(bz,ax,facecolors="deepskyblue",edgecolors="white",linewid
 PyObject <Axes3DSubplot: >
 ```
 """
-function plot_3Dconvexhull(convexhull::Chull{<:Real}, ax::Union{PyObject,Nothing}=nothing;
-    facecolors::String="blue",alpha::Real=0.3,linewidths::Real=1,edgecolors::String="black")::PyObject
-
-    ϵ=0.1*(convexhull.volume)^1/3
-    plotrange=[[minimum(convexhull.points[:,i])-ϵ,
-        maximum(convexhull.points[:,i])+ϵ] for i=1:3]
-
-    art3d=pyimport("mpl_toolkits.mplot3d.art3d")
-
-    facesᵢ=get_uniquefacets(convexhull)
-    edgesᵢ=deepcopy(facesᵢ)
-    for i=1:length(edgesᵢ)
-        append!(edgesᵢ[i],edgesᵢ[i][1])
-    end
-
-    faces=[convexhull.points[i,:] for i in facesᵢ]
-    edges=[convexhull.points[i,:] for i in edgesᵢ]
-
-    # Reshape faces and edges
-    faces=[[faces[j][i,:] for i=1:size(faces[j],1)] for j=1:length(faces)]
-    edges=[[edges[j][i,:] for i=1:size(edges[j],1)] for j=1:length(edges)]
-
-    p=art3d.Poly3DCollection(faces, alpha=alpha, facecolors=facecolors)
-    l=art3d.Line3DCollection(edges, colors=edgecolors,linewidths=linewidths)
-
-    if ax == nothing 
-        fig = figure()
-        ax = fig.add_subplot(111, projection="3d")
-    end
-
-    ax.add_collection3d(p)
-    ax.add_collection3d(l)
-    ax.auto_scale_xyz(plotrange[1],plotrange[2],plotrange[3])
-    ax.set_box_aspect((1, 1, 1))
-
-    return ax
-end
+function plot_3Dconvexhull end
 
 @doc """
     plot_convexhulls(real_latvecs,atom_types,atom_pos,coords,makeprim,convention;rtol,atol)
 
 Plot the Brillouin and Irreducible Brillouin zone in 2D or 3D.
+
+!!! note "PyPlot.jl package extension"
+    This function is available through a package extension of
+    [PyPlot.jl](https://github.com/JuliaPy/PyPlot.jl).
+    After installing Python, Matplotlib, and PyPlot.jl, do `using PyPlot` to load it.
 
 # Arguments
 - `real_latvecs::AbstractMatrix{<:Real}`: the basis of a real-space lattice as
@@ -174,6 +123,7 @@ Plot the Brillouin and Irreducible Brillouin zone in 2D or 3D.
 
 # Examples
 ```julia
+using PyPlot
 using SymmetryReduceBZ
 real_latvecs = [1 0; .5 1]
 atom_types=[0]
@@ -186,40 +136,6 @@ ax=plot_convexhulls(real_latvecs,atom_types,atom_pos,coords,makeprim,convention)
 PyObject <AxesSubplot: >
 ```
 """
-function plot_convexhulls(real_latvecs::AbstractMatrix{<:Real},
-    atom_types::AbstractVector{<:Int},atom_pos::AbstractMatrix{<:Real},
-    coords::String,makeprim::Bool,
-    convention::String,ax::Union{PyObject,Nothing}=nothing;
-    rtol::Real=sqrt(eps(float(maximum(real_latvecs)))),atol::Real=1e-9)::PyObject
-
-    art3d=pyimport("mpl_toolkits.mplot3d.art3d")
-    format = "convex hull"
-    bz = calc_bz(real_latvecs,atom_types,atom_pos,coords,format,makeprim,
-        convention,rtol=rtol,atol=atol)
-    ibz = calc_ibz(real_latvecs,atom_types,atom_pos,coords,format,makeprim,
-        convention,rtol=rtol,atol=atol)
-    dim = size(real_latvecs,1)
-
-    if ax == nothing
-        if dim == 2
-            fig,ax=subplots(figsize=figaspect(1)*1.5)
-        elseif dim == 3
-            fig = figure(figsize=figaspect(1)*1.5)
-            ax = fig.add_subplot(111, projection="3d")
-        else
-            throw(ArgumentError("The lattice vectors must be in a 2x2 or 3x3
-                matrix."))
-        end
-    end
-
-    if dim == 2
-        ax = plot_2Dconvexhull(bz,ax,facecolor="deepskyblue")
-        ax = plot_2Dconvexhull(ibz,ax,facecolor="coral")
-    else # dim == 3
-        ax = plot_3Dconvexhull(ibz,ax,facecolors="lightcoral")
-        ax = plot_3Dconvexhull(bz,ax,facecolors="deepskyblue")
-    end
-    ax
-end
+function plot_convexhulls end
 
 end #module

--- a/src/Symmetry.jl
+++ b/src/Symmetry.jl
@@ -758,7 +758,7 @@ coordinates = "Cartesian"
 convention = "ordinary"
 make_primitive(real_latvecs, atom_types, atom_pos, coordinates)
 # output
-([1.0 0.0 0.5; 0.0 1.0 0.5; 0.0 0.0 0.5], [0], [0.0; 0.0; 0.0])
+([1.0 0.0 0.5; 0.0 1.0 0.5; 0.0 0.0 0.5], [0], [0.0; 0.0; 0.0;;])
 ```
 """
 function make_primitive(real_latvecs::AbstractMatrix{<:Real},

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -1,5 +1,6 @@
 using Test
 
+using PyPlot
 import SymmetryReduceBZ
 import SymmetryReduceBZ.Plotting: plot_convexhulls
 


### PR DESCRIPTION
This pr creates a package extension for pyplot and puts all of the functionality there. The main motivation is that not all users will want the plotting in computational applications, so the dependencies will be reduced. Thus QHull.jl is the only additional dependency requiring Python and it would be interesting to eventually replace it and have a pure-Julia implementation (say v1 of SymmetryReduceBZ).

It is a breaking change, and also requires Julia v1.9, so this will require a minor version bump.

TODO

- [ ] Replace QHull.jl usage with Polyhedra.jl