### PR TITLE
make minkowski_reduce work for immutable inputs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymmetryReduceBZ"
 uuid = "49a35663-c880-4242-bebb-1ec8c0fa8046"
 authors = ["Jeremy Jorgensen <jerjorg@gmail.com>"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"

--- a/src/Lattices.jl
+++ b/src/Lattices.jl
@@ -204,13 +204,13 @@ function minkowski_reduce(basis::AbstractMatrix{<:Real};
 
     # Sort the lattice vectors by increasing norm.
     order = sortperm([basis[:,i] for i=axes(basis,1)])
-    rbasis = basis[:,order]
+    rbasis = Matrix(basis[:,order])
 
     k=2
     while k <= size(rbasis,1)
         k=reduce_basis!(rbasis,k,rtol=rtol,atol=atol)
     end
-    rbasis
+    oftype(basis, rbasis)
 end
 
 @doc """


### PR DESCRIPTION
#7 improved type stability and in some cases allowed SMatrices to retain their type for longer than before. Before #7 a SMatrix given to `minkowski_reduce` would become a Matrix by the time it got to `reduce_basis!`, but now the SMatrix survives and mutating it fails. This pr is a patch to make sure `minkowski_reduce` always passes a Matrix to `reduce_basis!`, thereby supporting more AbstractMatrix implementations.