### PR TITLE
Remove usage of gemv

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymmetryReduceBZ"
 uuid = "49a35663-c880-4242-bebb-1ec8c0fa8046"
 authors = ["Jeremy Jorgensen <jerjorg@gmail.com>"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"

--- a/src/Utilities.jl
+++ b/src/Utilities.jl
@@ -1,7 +1,6 @@
 module Utilities
 
 import LinearAlgebra: cross, dot, norm
-import LinearAlgebra.BLAS: gemv
 import Distances: euclidean
 import Base.Iterators: flatten
 import QHull: Chull
@@ -307,13 +306,12 @@ function sample_circle(basis::AbstractMatrix{<:Real}, radius::Real,
     n1,n2=round.(lens) .+ 1
 
     l=0;
-    pt=Array{Float64,1}(undef,2)
-    pts=Array{Float64,2}(undef,2,Int((2*n1+1)*(2*n2+1)));
-    distances=Array{Float64,1}(undef,size(pts,2))
+    pts=Matrix{eltype(basis)}(undef,2,Int((2*n1+1)*(2*n2+1)));
+    distances=Vector{float(eltype(basis))}(undef,size(pts,2))
     for (i,j) in Iterators.product((-n1+o1):(n1+o1),(-n2+o2):(n2+o2))
         l+=1
-        pt=gemv('N',float(basis),[i,j])
-        pts[:,l]=pt
+        pt= basis * [i, j]
+        pts[:,l] = pt
         distances[l]=euclidean(pt,offset)
     end
 
@@ -365,13 +363,12 @@ function sample_sphere(basis::AbstractMatrix{<:Real}, radius::Real,
     n1,n2,n3=round.(lens) .+ 1
 
     l=0;
-    pt=Array{Float64,1}(undef,3)
-    pts=Array{Float64,2}(undef,3,Int((2*n1+1)*(2*n2+1)*(2*n3+1)));
-    distances=Array{Float64,1}(undef,size(pts,2))
+    pts=Matrix{eltype(basis)}(undef,3,Int((2*n1+1)*(2*n2+1)*(2*n3+1)));
+    distances=Vector{float(eltype(basis))}(undef,size(pts,2))
     for (i,j,k) in Iterators.product((-n1+o1):(n1+o1),(-n2+o2):(n2+o2),
                                      (-n3+o3):(n3+o3))
         l+=1
-        pt=gemv('N',float(basis),[i,j,k])
+        pt= basis * [i,j,k]
         pts[:,l]=pt
         distances[l]=euclidean(pt,offset)
     end


### PR DESCRIPTION
Calling BLAS directly was unnecessary when `*` could do the same for generic types.