### PR TITLE
Patch for v0.1.10

### DIFF
--- a/src/Symmetry.jl
+++ b/src/Symmetry.jl
@@ -448,7 +448,7 @@ function calc_spacegroup(real_latvecs::AbstractMatrix{<:Real},
     atom_pos = mapto_unitcell(atom_pos_1[:,1:numatoms],real_latvecs,inv_latvecs,"Cartesian",rtol=rtol,atol=atol)
 
     ops_spacegroup=empty!(similar(pointgroup))
-    trans_spacegroup=typeof(atom_pos)[]
+    trans_spacegroup=typeof(atom_pos[:,begin])[]
     kindᵣ=atom_types[1]
     # opts = Array{Float64,1}[]
 

--- a/src/Symmetry.jl
+++ b/src/Symmetry.jl
@@ -205,7 +205,7 @@ function mapto_bz(kpoint::AbstractVector{<:Real},
 
     coordinates == "lattice" && (uc_point = recip_latvecs*uc_point)
 
-    bz_dist = Inf
+    bz_dist = typemax(norm(uc_point))
     bz_point = similar(uc_point)
 
     if checksquare(recip_latvecs) == 2

--- a/src/Symmetry.jl
+++ b/src/Symmetry.jl
@@ -25,7 +25,7 @@ Calculate the point group of a lattice in 2D or 3D.
     used to compare lengths of vectors and the volumes of primitive cells.
 
 # Returns
-- `pointgroup::AbstractVector{<:Matrix{<:Real}}`: the point group of the lattice. The
+- `pointgroup::AbstractVector{<:AbstractMatrix{<:Real}}`: the point group of the lattice. The
     operators operate on points in Cartesian coordinates from the right.
 
 # Examples
@@ -306,7 +306,7 @@ Map a point to a symmetrically equivalent point within the IBZ.
     `recip_latvecs`.
 - `ibz::Chull`: the irreducible Brillouin zone as as a convex hull
     objects from `QHull`.
-- `pointgroup::AbstractVector{<:Matrix{<:Real}}`: a list of point symmetry operators
+- `pointgroup::AbstractVector{<:AbstractMatrix{<:Real}}`: a list of point symmetry operators
     in matrix form that operate on points from the left.
 - `coordinates::String`: the coordinates the *k*-point is in. Options are
     \"lattice\" and \"Cartesian\". The *k*-point within the IBZ is returned in
@@ -350,7 +350,7 @@ ibz_point = mapto_ibz(kpoint,recip_latvecs,inv_rlatvecs,ibz,pg,coordinates)
 function mapto_ibz(kpoint::AbstractVector{<:Real},
         recip_latvecs::AbstractMatrix{<:Real},
         inv_rlatvecs::AbstractMatrix{<:Real}, ibz::Chull,
-        pointgroup::AbstractVector{<:Matrix{<:Real}}, coordinates::String;
+        pointgroup::AbstractVector{<:AbstractMatrix{<:Real}}, coordinates::String;
         rtol::Real=sqrt(eps(float(maximum(recip_latvecs)))),
         atol::Real=1e-9)
 
@@ -380,7 +380,7 @@ Map points as columns of a matrix to the IBZ and then remove duplicate points.
 function mapto_ibz(kpoints::AbstractMatrix{<:Real},
         recip_latvecs::AbstractMatrix{<:Real},
         inv_rlatvecs::AbstractMatrix{<:Real}, ibz::Chull,
-        pointgroup::AbstractVector{<:Matrix{<:Real}}, coordinates::String;
+        pointgroup::AbstractVector{<:AbstractMatrix{<:Real}}, coordinates::String;
         rtol::Real=sqrt(eps(float(maximum(recip_latvecs)))),
         atol::Real=1e-9)
 

--- a/src/Symmetry.jl
+++ b/src/Symmetry.jl
@@ -203,11 +203,8 @@ function mapto_bz(kpoint::AbstractVector{<:Real},
     uc_point = mapto_unitcell(kpoint,recip_latvecs,inv_rlatvecs,coordinates,
         rtol=rtol,atol=atol)
 
-    coordinates == "lattice" && (uc_point = recip_latvecs*uc_point)
-
-    bz_dist = typemax(norm(uc_point))
-    bz_point = similar(uc_point)
-
+    bz_point = uc_point = coordinates == "lattice" ? recip_latvecs*uc_point : uc_point
+    bz_dist = norm(bz_point)
     if checksquare(recip_latvecs) == 2
         shifts = collect.(product(0:-1:-1,0:-1:-1))
     else


### PR DESCRIPTION
This is a patch intended for a v0.1.10 release of SymmetryReduceBZ. It loosens type annotations for `pointgroup` that should allow more generic input types and it makes recent changes in bugfix #20 more type stable by making fewer assumptions about input types in `mapto_bz`.